### PR TITLE
LongClassNameCheck

### DIFF
--- a/.github/workflows/pdd.yaml
+++ b/.github/workflows/pdd.yaml
@@ -1,10 +1,14 @@
-name: pdd check
+name: pdd
 on:
   push:
+    branches:
+      - master
   pull_request:
+    branches:
+      - master
 jobs:
-  build:
-    runs-on: ubuntu-latest
+  pdd:
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
-      - uses: g4s8/pdd-action@master
+      - uses: actions/checkout@v4
+      - uses: volodya-lombrozo/pdd-action@master

--- a/src/it/long-class-name/pom.xml
+++ b/src/it/long-class-name/pom.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ The MIT License (MIT)
+  ~
+  ~ Copyright (c) 2023. Ivanchuck Ivan.
+  ~
+  ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~ of this software and associated documentation files (the "Software"), to deal
+  ~ in the Software without restriction, including without limitation the rights
+  ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~ copies of the Software, and to permit persons to whom the Software is
+  ~ furnished to do so, subject to the following conditions:
+  ~
+  ~ The above copyright notice and this permission notice shall be included
+  ~ in all copies or substantial portions of the Software.
+  ~
+  ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~ FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+  ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  ~ SOFTWARE.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>ru.incorrect</groupId>
+  <artifactId>it-incorrect</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>8</maven.compiler.source>
+    <maven.compiler.target>8</maven.compiler.target>
+    <junit.version>5.10.0</junit.version>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>${junit.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <version>${junit.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>ru.l3r8y</groupId>
+        <artifactId>sa-tan</artifactId>
+        <version>1.0-SNAPSHOT</version>
+        <executions>
+          <execution>
+            <id>integration-test</id>
+            <goals>
+              <goal>search</goal>
+            </goals>
+            <configuration>
+              <failOnError>false</failOnError>
+              <okClassNameLength>15</okClassNameLength>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/long-class-name/pom.xml
+++ b/src/it/long-class-name/pom.xml
@@ -63,7 +63,7 @@
             </goals>
             <configuration>
               <failOnError>false</failOnError>
-              <okClassNameLength>15</okClassNameLength>
+              <maxClassNameLen>15</maxClassNameLen>
             </configuration>
           </execution>
         </executions>

--- a/src/it/long-class-name/src/main/java/ClassNameIsTooComplex.java
+++ b/src/it/long-class-name/src/main/java/ClassNameIsTooComplex.java
@@ -1,0 +1,11 @@
+public class ClassNameIsTooComplex {
+    private final String field;
+
+    ClassNameIsTooComplex(final String field) {
+        this.field = field;
+    }
+
+    public String getField() {
+        return field;
+    }
+}

--- a/src/it/long-class-name/verify.groovy
+++ b/src/it/long-class-name/verify.groovy
@@ -1,0 +1,29 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2023. Ivanchuck Ivan.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+String log = new File(basedir, 'build.log').text;
+[
+  "Class 'ClassNameIsTooComplex' has bad naming, class name is more than 15, it's too complex. Consider more simple name, read: https://www.yegor256.com/2015/01/12/compound-name-is-code-smell.html"
+].each { assert log.contains(it): "Log doesn't contain ['$it']" }
+true

--- a/src/main/java/ru/l3r8y/ValidateMojo.java
+++ b/src/main/java/ru/l3r8y/ValidateMojo.java
@@ -35,6 +35,7 @@ import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 import ru.l3r8y.complaint.CompoundComplaint;
 import ru.l3r8y.rule.CompositeErNamedClass;
+import ru.l3r8y.rule.CompositeLongClassName;
 import ru.l3r8y.rule.CompositeMethodsContainsAssigment;
 
 /**
@@ -54,11 +55,22 @@ public final class ValidateMojo extends AbstractMojo {
 
     /**
      * The fail on error.
+     *
      * @checkstyle MemberNameCheck (6 lines).
      */
     @SuppressWarnings("PMD.ImmutableField")
     @Parameter(defaultValue = "true")
     private boolean failOnError = true;
+
+    /**
+     * Length of Class Name.
+     *
+     * @see ru.l3r8y.rule.LongClassNameCheck
+     * @checkstyle MemberNameCheck (6 lines).
+     */
+    @SuppressWarnings("PMD.ImmutableField")
+    @Parameter
+    private int okClassNameLength = 13;
 
     @Override
     public void execute() throws MojoFailureException {
@@ -67,6 +79,11 @@ public final class ValidateMojo extends AbstractMojo {
         final List<Complaint> complaints = new ArrayList<>(0);
         complaints.addAll(new CompositeMethodsContainsAssigment(start).complaints());
         complaints.addAll(new CompositeErNamedClass(start).complaints());
+        complaints.addAll(
+            new CompositeLongClassName(
+                start, this.okClassNameLength
+            ).complaints()
+        );
         if (!complaints.isEmpty() && this.failOnError) {
             throw new MojoFailureException(new CompoundComplaint(complaints).message());
         }

--- a/src/main/java/ru/l3r8y/ValidateMojo.java
+++ b/src/main/java/ru/l3r8y/ValidateMojo.java
@@ -70,7 +70,7 @@ public final class ValidateMojo extends AbstractMojo {
      */
     @SuppressWarnings("PMD.ImmutableField")
     @Parameter
-    private int okClassNameLength = 13;
+    private int maxClassNameLen = 13;
 
     @Override
     public void execute() throws MojoFailureException {
@@ -81,7 +81,7 @@ public final class ValidateMojo extends AbstractMojo {
         complaints.addAll(new CompositeErNamedClass(start).complaints());
         complaints.addAll(
             new CompositeLongClassName(
-                start, this.okClassNameLength
+                start, this.maxClassNameLen
             ).complaints()
         );
         if (!complaints.isEmpty() && this.failOnError) {

--- a/src/main/java/ru/l3r8y/rule/CompositeLongClassName.java
+++ b/src/main/java/ru/l3r8y/rule/CompositeLongClassName.java
@@ -1,0 +1,111 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2023. Ivanchuck Ivan.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package ru.l3r8y.rule;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import lombok.RequiredArgsConstructor;
+import ru.l3r8y.ClassName;
+import ru.l3r8y.Complaint;
+import ru.l3r8y.Rule;
+import ru.l3r8y.parser.ClassNames;
+
+/**
+ * Composite Long Class Name.
+ *
+ * @since 0.2.0
+ */
+@RequiredArgsConstructor
+public final class CompositeLongClassName implements Rule {
+
+    /**
+     * Path to start.
+     */
+    private final Path start;
+
+    /**
+     * Length to pass.
+     */
+    private final int fine;
+
+    @Override
+    public Collection<Complaint> complaints() {
+        final List<Complaint> accum;
+        if (Files.exists(this.start)) {
+            try (Stream<Path> files = Files.walk(this.start)) {
+                accum = files
+                    .filter(Files::exists)
+                    .filter(Files::isRegularFile)
+                    .filter(p -> p.toString().endsWith(".java"))
+                    .map(ClassNames::new)
+                    .map(ClassNames::all)
+                    .map(this::checkLongName)
+                    .flatMap(Collection::stream)
+                    .collect(Collectors.toList());
+            } catch (final IOException ex) {
+                throw new IllegalStateException(
+                    String.format(
+                        "Error occupied while checking java sources: %s\n",
+                        ex.getMessage()
+                    ),
+                    ex
+                );
+            }
+        } else {
+            accum = Collections.emptyList();
+        }
+        return accum;
+    }
+
+    /**
+     * Checks long class name in a collection of names.
+     * @param names Class names
+     * @return Complaints.
+     * @todo #81 Introduce new class from #checkLongName private method.
+     *  we should introduce new reusable class from private method
+     *  #checkLongName.
+     *  Don't forget to remove this puzzle.
+     */
+    private Collection<Complaint> checkLongName(final Collection<ClassName> names) {
+        final Collection<Complaint> result;
+        if (names.isEmpty()) {
+            result = Collections.emptyList();
+        } else {
+            final Collection<Complaint> cmps = new ArrayList<>(0);
+            names.stream()
+                .map(cl -> new LongClassNameCheck(cl, this.fine))
+                .map(LongClassNameCheck::complaints)
+                .forEach(cmps::addAll);
+            result = cmps;
+        }
+        return result;
+    }
+}

--- a/src/main/java/ru/l3r8y/rule/LongClassNameCheck.java
+++ b/src/main/java/ru/l3r8y/rule/LongClassNameCheck.java
@@ -1,0 +1,79 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2023. Ivanchuck Ivan.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package ru.l3r8y.rule;
+
+import java.util.Collection;
+import lombok.RequiredArgsConstructor;
+import ru.l3r8y.ClassName;
+import ru.l3r8y.Complaint;
+import ru.l3r8y.Rule;
+import ru.l3r8y.complaint.WrongClassNamingComplaint;
+
+/**
+ * Check for Long class name.
+ *
+ * @since 0.2.0
+ */
+@RequiredArgsConstructor
+public final class LongClassNameCheck implements Rule {
+
+    /**
+     * Class name.
+     */
+    private final ClassName name;
+
+    /**
+     * Length to pass.
+     */
+    private final int fine;
+
+    @Override
+    public Collection<Complaint> complaints() {
+        return new ConditionRule(
+            this::longerThanOk,
+            new WrongClassNamingComplaint(
+                this.name,
+                // @checkstyle StringLiteralsConcatenationCheck (4 lines).
+                String.format(
+                    "class name is more than %s, it's too complex."
+                    + " Consider more simple name,"
+                    + " read: https://www.yegor256.com/2015/01/12/compound-name-is-code-smell.html",
+                    this.fine
+                )
+            )
+        ).complaints();
+    }
+
+    /**
+     * Is name ok?
+     * @return True if longer
+     * @todo #81 Introduce new class from #longerThanOk private method.
+     *  we should introduce new reusable class from private method
+     *  #longerThanOk.
+     *  Don't forget to remove this puzzle.
+     */
+    private boolean longerThanOk() {
+        return this.name.value().length() > this.fine;
+    }
+}

--- a/src/test/java/ru/l3r8y/extensions/LongNamedClass.java
+++ b/src/test/java/ru/l3r8y/extensions/LongNamedClass.java
@@ -1,0 +1,55 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2023. Ivanchuck Ivan.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package ru.l3r8y.extensions;
+
+import java.nio.file.Path;
+import java.util.Objects;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolver;
+import ru.l3r8y.fake.FakeClass;
+
+/**
+ * JUnit parameter resolver for {@link ru.l3r8y.rule.LongClassNameCheck}.
+ *
+ * @since 0.2.0
+ */
+public final class LongNamedClass implements ParameterResolver {
+
+    @Override
+    public boolean supportsParameter(
+        final ParameterContext pctx,
+        final ExtensionContext ectx
+    ) {
+        return Objects.equals(pctx.getParameter().getType(), Path.class);
+    }
+
+    @Override
+    public Object resolveParameter(
+        final ParameterContext pctx,
+        final ExtensionContext ectx) {
+        return new FakeClass("AbstractSynchronizedFactory.java").asPath();
+    }
+
+}

--- a/src/test/java/ru/l3r8y/rule/LongClassNameCheckTest.java
+++ b/src/test/java/ru/l3r8y/rule/LongClassNameCheckTest.java
@@ -1,0 +1,60 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2023. Ivanchuck Ivan.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package ru.l3r8y.rule;
+
+import java.nio.file.Path;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import ru.l3r8y.extensions.LongNamedClass;
+import ru.l3r8y.extensions.ValidClass;
+
+/**
+ * Test case for {@link ru.l3r8y.rule.LongClassNameCheck}.
+ *
+ * @since 0.2.0
+ */
+final class LongClassNameCheckTest {
+
+    @Test
+    @ExtendWith(LongNamedClass.class)
+    void failsWithErOnEnd(final Path clazz) {
+        MatcherAssert.assertThat(
+            "Build is not failed as expected",
+            new CompositeLongClassName(clazz, 15).complaints(),
+            Matchers.not(Matchers.empty())
+        );
+    }
+
+    @Test
+    @ExtendWith(ValidClass.class)
+    void passesWhenNameIsFine(final Path clazz) {
+        MatcherAssert.assertThat(
+            "Build is not successed as expected",
+            new CompositeLongClassName(clazz, 13).complaints(),
+            Matchers.empty()
+        );
+    }
+}

--- a/src/test/resources/AbstractSynchronizedFactory.java
+++ b/src/test/resources/AbstractSynchronizedFactory.java
@@ -1,0 +1,1 @@
+class AbstractSynchronizedFactory {}


### PR DESCRIPTION
@l3r8yJ take a look, please
closes #81

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of this PR:
- Introduces a new rule for checking long class names
- Updates the PDD workflow to use a different action
- Adds test cases for the new rule
- Updates the `ValidateMojo` class to include the new rule
- Adds a new parameter for specifying the maximum length of class names

### Detailed summary:
- Added `LongClassNameCheck` rule to check for long class names
- Updated PDD workflow to use `volodya-lombrozo/pdd-action@master`
- Added test cases for `LongClassNameCheck`
- Updated `ValidateMojo` class to include `LongClassNameCheck` rule
- Added `maxClassNameLen` parameter to `ValidateMojo` for specifying maximum class name length

> The following files were skipped due to too many changes: `src/it/long-class-name/pom.xml`, `src/main/java/ru/l3r8y/rule/CompositeLongClassName.java`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->